### PR TITLE
fix: add navbar flag to adobe auth plugin

### DIFF
--- a/plugins/quick-brick-adobe-primetime-auth/index.js
+++ b/plugins/quick-brick-adobe-primetime-auth/index.js
@@ -6,6 +6,7 @@ const AdobePlugin = {
   Component: withNavigator(AdobeComponent),
   isFlowBlocker: () => true,
   presentFullScreen: true,
+  showNavBar: true,
   hasPlayerHook: true
 };
 

--- a/plugins/quick-brick-adobe-primetime-auth/src/ReactNative/AdobeComponent.js
+++ b/plugins/quick-brick-adobe-primetime-auth/src/ReactNative/AdobeComponent.js
@@ -53,8 +53,6 @@ class AdobeComponent extends Component {
       configuration
     } = this.props;
 
-    this.props.navigator.showNavBar();
-
     const requiresAuth = R.pathOr(false, ['extensions', 'requires_authentication'], payload);
     if (!R.isEmpty(payload) && !requiresAuth) {
       return callback({ success: true, payload });


### PR DESCRIPTION

Because of a change done on the QB core regarding the handling of navigation & transitions, the navbar flag introduced in #33  no longer works properly

instead, we wish to introduce a static flag in the plugin declaration.

This PR adds this flag.

The changes haven't been done yet on the QB core side, but if you're fine with that change on your end, I can include it and restore the proper display of the navbar, whether the screen is presented as a hook or from a button