### PR TITLE
feat(IMA):  add accessibility identifiers into IMA plugin for UI tests needs

### DIFF
--- a/FrameworksData.plist
+++ b/FrameworksData.plist
@@ -5,7 +5,7 @@
 	<key>ZappGoogleInteractiveMediaAds</key>
 	<dict>
 		<key>version_id</key>
-		<string>0.10.1</string>
+		<string>0.10.2</string>
 	</dict>
 	<key>quick-brick-circle-ci-test</key>
 	<dict>

--- a/plugins/ZappGoogleInteractiveMediaAds/Universal/GoogleInteractiveMediaAdsAdapter/GoogleInteractiveMediaAdsAdapter.swift
+++ b/plugins/ZappGoogleInteractiveMediaAds/Universal/GoogleInteractiveMediaAdsAdapter/GoogleInteractiveMediaAdsAdapter.swift
@@ -56,6 +56,8 @@ import ZappCore
 
     /// Main point of interaction with the SDK. Created by the SDK as the result of an ad request.
     internal var adsManager: IMAAdsManager?
+    
+    internal var adDisplayContainer: IMAAdDisplayContainer?
 
     var avPlayer: AVPlayer? {
         return playerPlugin?.playerObject as? AVPlayer
@@ -132,6 +134,7 @@ import ZappCore
     func resumePlayback() {
         isPlaybackPaused = false
         playerPlugin?.pluggablePlayerResume()
+        adDisplayContainer?.adContainer.accessibilityIdentifier = ""
     }
     
     func pausePlayback() {
@@ -170,14 +173,16 @@ import ZappCore
         }
         setupAdsLoader()
 
-        let adDisplayContainer: IMAAdDisplayContainer = IMAAdDisplayContainer(adContainer: containerView,
-                                                                              companionSlots: nil)
+        adDisplayContainer = IMAAdDisplayContainer(adContainer: containerView, companionSlots: nil)
         if let request = IMAAdsRequest(adTagUrl: adUrl,
                                        adDisplayContainer: adDisplayContainer,
                                        contentPlayhead: contentPlayhead,
                                        userContext: nil) {
             adRequest = request
             adsLoader?.requestAds(with: adRequest)
+            
+            // Adding accessibility identifier for UI automation tests needs
+            adDisplayContainer?.adContainer.accessibilityIdentifier = adUrl
         }
     }
 }


### PR DESCRIPTION
This PR adds accessibility identifier for automation matters for the IMA player ad container when pre-roll, mid-roll or post roll are playing.

The accessibility id is removed the adContainer when the adv finishes playing and the playing continue playing. 

The used id is the url to the VAST/VMAP