### PR TITLE
fix(IMA-acc-id): enable showing accessibility identifiers for IMA in case of VMAP url too

### DIFF
--- a/FrameworksData.plist
+++ b/FrameworksData.plist
@@ -5,7 +5,7 @@
 	<key>ZappGoogleInteractiveMediaAds</key>
 	<dict>
 		<key>version_id</key>
-		<string>0.10.3</string>
+		<string>0.10.4</string>
 	</dict>
 	<key>quick-brick-circle-ci-test</key>
 	<dict>

--- a/plugins/ZappGoogleInteractiveMediaAds/Universal/GoogleInteractiveMediaAdsAdapter/GoogleInteractiveMediaAdsAdapter.swift
+++ b/plugins/ZappGoogleInteractiveMediaAds/Universal/GoogleInteractiveMediaAdsAdapter/GoogleInteractiveMediaAdsAdapter.swift
@@ -58,6 +58,8 @@ import ZappCore
     internal var adsManager: IMAAdsManager?
     
     internal var adDisplayContainer: IMAAdDisplayContainer?
+    
+    internal var advAccessibilityIdentifier: String?
 
     var avPlayer: AVPlayer? {
         return playerPlugin?.playerObject as? AVPlayer
@@ -134,12 +136,19 @@ import ZappCore
     func resumePlayback() {
         isPlaybackPaused = false
         playerPlugin?.pluggablePlayerResume()
-        adDisplayContainer?.adContainer.accessibilityIdentifier = ""
+        
+        if adDisplayContainer == adDisplayContainer {
+            adDisplayContainer?.adContainer.accessibilityIdentifier = ""
+        }
     }
     
     func pausePlayback() {
         isPlaybackPaused = true
         playerPlugin?.pluggablePlayerPause()
+        
+        if adDisplayContainer == adDisplayContainer {
+            adDisplayContainer?.adContainer.accessibilityIdentifier = advAccessibilityIdentifier
+        }
     }
     
     func showActivityIndicator(_ show: Bool) {
@@ -181,8 +190,8 @@ import ZappCore
             adRequest = request
             adsLoader?.requestAds(with: adRequest)
             
-            // Adding accessibility identifier for UI automation tests needs
-            adDisplayContainer?.adContainer.accessibilityIdentifier = adUrl
+            // Storing accessibility identifier for UI automation tests needs
+            advAccessibilityIdentifier = adUrl
         }
     }
 }


### PR DESCRIPTION
Originally I was adding the acc-id only when the IMA containers were allocated, and when the player resume playing I was removing the acc-id.

In case of VMAP the container is being allocated only once, so I did not have acc-id when the mid and post roll adv were showing. 

This PR adding the acc-id according to the pause/resume playing of the player. 
