### PR TITLE
feat(ui-tests): add accessibility identifiers to AdMob inline banners

### DIFF
--- a/plugins/quick-brick-google-admob-inline-banner/src/BannerWrapper.js
+++ b/plugins/quick-brick-google-admob-inline-banner/src/BannerWrapper.js
@@ -24,7 +24,11 @@ export default function BannerWrapper(props) {
   }
 
   return (
-    <View style={[styles.container, { backgroundColor: bannerBackground }, accessibilityLabel]}>
+    <View
+      style={[styles.container, { backgroundColor: bannerBackground }]}
+      accessibilityLabel={accessibilityLabel}
+      testID={accessibilityLabel}
+    >
       {
         showBackground && (
           <Text
@@ -36,10 +40,7 @@ export default function BannerWrapper(props) {
           </Text>
         )
       }
-      <View
-        accessibilityLabel={accessibilityLabel}
-        testID={accessibilityLabel}
-      >
+      <View>
         {children}
       </View>
     </View>

--- a/plugins/quick-brick-google-admob-inline-banner/src/BannerWrapper.js
+++ b/plugins/quick-brick-google-admob-inline-banner/src/BannerWrapper.js
@@ -9,7 +9,8 @@ export default function BannerWrapper(props) {
     backgroundColor,
     titleStyle,
     title,
-    children
+    children,
+    accessibilityLabel
   } = props;
 
   const bannerBackground = showBackground ? backgroundColor : '';
@@ -23,7 +24,7 @@ export default function BannerWrapper(props) {
   }
 
   return (
-    <View style={[styles.container, { backgroundColor: bannerBackground }]}>
+    <View style={[styles.container, { backgroundColor: bannerBackground }, accessibilityLabel]}>
       {
         showBackground && (
           <Text
@@ -35,7 +36,10 @@ export default function BannerWrapper(props) {
           </Text>
         )
       }
-      <View>
+      <View
+        accessibilityLabel={accessibilityLabel}
+        testID={accessibilityLabel}
+      >
         {children}
       </View>
     </View>

--- a/plugins/quick-brick-google-admob-inline-banner/src/InlineBanner.js
+++ b/plugins/quick-brick-google-admob-inline-banner/src/InlineBanner.js
@@ -80,6 +80,7 @@ export default function InlineBanner(props) {
       backgroundColor={backgroundColor}
       titleStyle={titleStyle}
       title={title}
+      accessible={false}
       accessibilityLabel={bannerAdUnit}
     >
       <BannerAd

--- a/plugins/quick-brick-google-admob-inline-banner/src/InlineBanner.js
+++ b/plugins/quick-brick-google-admob-inline-banner/src/InlineBanner.js
@@ -80,6 +80,7 @@ export default function InlineBanner(props) {
       backgroundColor={backgroundColor}
       titleStyle={titleStyle}
       title={title}
+      accessibilityLabel={bannerAdUnit}
     >
       <BannerAd
         unitId={bannerAdUnit}


### PR DESCRIPTION
This PR adds accessibility identifiers for the UI Tests.
The acc-id that is being added to the adv view is the ad-unit as defined in the UIBuider. 

During the test run it will verify that the exact id is found on the screen, that id is reflecting the adv view

`testID` - for iOS automation
`accessibilityLabel` - for Android automation 