### PR TITLE
fix: parental challenge now with numbers

### DIFF
--- a/plugins/quick-brick-parent-lock/src/Utils/Utils.js
+++ b/plugins/quick-brick-parent-lock/src/Utils/Utils.js
@@ -43,7 +43,7 @@ export function createChallenge(textTranform) {
   } else {
     secondNum = getRandomInt(10, minimalValue);
   }
-  let resultString = names[firstNum - 1] + " X " + names[secondNum - 1];
+  let resultString = names[firstNum - 1] + " x " + names[secondNum - 1];
   resultString = updateString(resultString, textTranform);
   const result = firstNum * secondNum;
   return { string: resultString, number: result };


### PR DESCRIPTION
This PR introduces the use of numbers instead of strings with names of numbers for the parental lock challenge.

So users would see: 
```{ string: '3 X 5', number: 15 }```

Instead of: 

```{ string: 'Three times Five', number: 15 }```