### PR TITLE
chore: publish @applicaster/quick-brick-parent-lock@0.0.8

### DIFF
--- a/plugins/quick-brick-parent-lock/manifests/android.json
+++ b/plugins/quick-brick-parent-lock/manifests/android.json
@@ -435,8 +435,8 @@
     "quickbrick"
   ],
   "platform": "android",
-  "dependency_version": "0.0.7",
-  "manifest_version": "0.0.7",
+  "dependency_version": "0.0.8",
+  "manifest_version": "0.0.8",
   "min_zapp_sdk": "20.0.0-Dev",
   "npm_dependencies": []
 }

--- a/plugins/quick-brick-parent-lock/manifests/android_for_quickbrick.json
+++ b/plugins/quick-brick-parent-lock/manifests/android_for_quickbrick.json
@@ -435,8 +435,8 @@
     "quickbrick"
   ],
   "platform": "android_for_quickbrick",
-  "dependency_version": "0.0.7",
-  "manifest_version": "0.0.7",
+  "dependency_version": "0.0.8",
+  "manifest_version": "0.0.8",
   "min_zapp_sdk": "0.1.0-alpha1",
   "npm_dependencies": []
 }

--- a/plugins/quick-brick-parent-lock/manifests/ios.json
+++ b/plugins/quick-brick-parent-lock/manifests/ios.json
@@ -435,8 +435,8 @@
     "quickbrick"
   ],
   "platform": "ios",
-  "dependency_version": "0.0.7",
-  "manifest_version": "0.0.7",
+  "dependency_version": "0.0.8",
+  "manifest_version": "0.0.8",
   "min_zapp_sdk": "20.0.0-Dev",
   "npm_dependencies": []
 }

--- a/plugins/quick-brick-parent-lock/manifests/ios_for_quickbrick.json
+++ b/plugins/quick-brick-parent-lock/manifests/ios_for_quickbrick.json
@@ -435,8 +435,8 @@
     "quickbrick"
   ],
   "platform": "ios_for_quickbrick",
-  "dependency_version": "0.0.7",
-  "manifest_version": "0.0.7",
+  "dependency_version": "0.0.8",
+  "manifest_version": "0.0.8",
   "min_zapp_sdk": "0.1.0-alpha1",
   "npm_dependencies": []
 }

--- a/plugins/quick-brick-parent-lock/package.json
+++ b/plugins/quick-brick-parent-lock/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@applicaster/quick-brick-parent-lock",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Found out today that version 0.0.5 of the Parent Lock plugin was never published to Github or NPM. So when I pushed 0.0.6 and 0.0.7 it was missing changes that were published to Zapp previously.

This PR brings in those manifest changes from: https://zapp.applicaster.com/admin/plugin_versions/19776/plugin_manifests/19776#

