### PR TITLE
chore: parental lock update

### DIFF
--- a/plugins/quick-brick-parent-lock/manifests/android.json
+++ b/plugins/quick-brick-parent-lock/manifests/android.json
@@ -435,8 +435,8 @@
     "quickbrick"
   ],
   "platform": "android",
-  "dependency_version": "0.0.7",
-  "manifest_version": "0.0.7",
+  "dependency_version": "0.0.8",
+  "manifest_version": "0.0.8",
   "min_zapp_sdk": "20.0.0-Dev",
   "npm_dependencies": []
 }

--- a/plugins/quick-brick-parent-lock/manifests/android.json
+++ b/plugins/quick-brick-parent-lock/manifests/android.json
@@ -20,6 +20,13 @@
   "general": {
     "fields": [
       {
+        "type": "switch",
+        "key": "import_parent_lock",
+        "label": "Import Parent Lock",
+        "label_tooltip": "Import Parent lock in other supported plugins.",
+        "initial_value": "true"
+      },
+      {
         "group": true,
         "label": "Screen Design and Text",
         "tooltip": "These fields affect the design of the main screen plugin.",
@@ -29,7 +36,7 @@
             "type": "select",
             "key": "background_type",
             "label": "Background type",
-            "tooltip_text": "Defines whether the background will use an image or a solid color.",
+            "label_tooltip": "Defines whether the background will use an image or a solid color.",
             "options": [
               {
                 "text": "Color",
@@ -59,13 +66,13 @@
             "type": "uploader",
             "key": "close_button_image",
             "label": "Close Button Image",
-            "label_tooltip": "Image for the screen background."
+            "label_tooltip": "Image for the close button of the screen."
           },
           {
             "type": "select",
             "key": "close_button_position",
             "label": "Close Button Position",
-            "tooltip_text": "Determines the corner side of the screen where the button is placed.",
+            "label_tooltip": "Determines the corner side of the screen where the button is placed.",
             "options": [
               {
                 "text": "Left",
@@ -117,7 +124,7 @@
             "type": "select",
             "key": "instructions_text_transform",
             "label": "Instructions Text Transform",
-            "tooltip_text": "Reformats the Instructions Text if needed.",
+            "label_tooltip": "Reformats the Instructions Text if needed.",
             "options": [
               {
                 "text": "None",
@@ -177,7 +184,7 @@
             "type": "select",
             "key": "challenge_text_transform",
             "label": "Challenge Text Transform",
-            "tooltip_text": "Reformats the Code/Challenge Text if needed.",
+            "label_tooltip": "Reformats the Code/Challenge Text if needed.",
             "options": [
               {
                 "text": "None",
@@ -202,7 +209,7 @@
             "type": "number_input",
             "key": "challenge_text_margin",
             "label": "Challenge Text Margin",
-            "label_tooltip": "Margin between the Instructions section and the Code/Challenge section.",
+            "label_tooltip": "Margin between the Code/Challenge section and the Indicators/Answer section.",
             "initial_value": "16"
           },
           {
@@ -244,7 +251,7 @@
             "type": "select",
             "key": "error_message_text_transform",
             "label": "Error Message Text Transform",
-            "tooltip_text": "Reformats the Error Message Text if needed.",
+            "label_tooltip": "Reformats the Error Message Text if needed.",
             "options": [
               {
                 "text": "None",
@@ -425,9 +432,30 @@
       }
     ]
   },
-  "styles": {},
-  "data": {},
-  "localizations": {},
+  "export": {
+    "allowed_list": [
+      {
+        "identifier": "quick-brick-inplayer",
+        "group": {
+          "label": "Parent Lock Import",
+          "folded": true
+        },
+        "section": "styles",
+        "allowed_fields": [
+          {
+            "section": "general",
+            "key": "import_parent_lock",
+            "min_zapp_sdk": {
+              "ios": "20.2.0-Dev",
+              "android": "20.0.0",
+              "ios_for_quickbrick": "0.1.0-alpha1",
+              "android_for_quickbrick": "0.1.0-alpha1"
+            }
+          }
+        ]
+      }
+    ]
+  },
   "targets": [
     "mobile"
   ],
@@ -435,8 +463,8 @@
     "quickbrick"
   ],
   "platform": "android",
-  "dependency_version": "0.0.8",
-  "manifest_version": "0.0.8",
+  "dependency_version": "0.0.9",
+  "manifest_version": "0.0.9",
   "min_zapp_sdk": "20.0.0-Dev",
   "npm_dependencies": []
 }

--- a/plugins/quick-brick-parent-lock/manifests/android_for_quickbrick.json
+++ b/plugins/quick-brick-parent-lock/manifests/android_for_quickbrick.json
@@ -20,6 +20,13 @@
   "general": {
     "fields": [
       {
+        "type": "switch",
+        "key": "import_parent_lock",
+        "label": "Import Parent Lock",
+        "label_tooltip": "Import Parent lock in other supported plugins.",
+        "initial_value": "true"
+      },
+      {
         "group": true,
         "label": "Screen Design and Text",
         "tooltip": "These fields affect the design of the main screen plugin.",
@@ -29,7 +36,7 @@
             "type": "select",
             "key": "background_type",
             "label": "Background type",
-            "tooltip_text": "Defines whether the background will use an image or a solid color.",
+            "label_tooltip": "Defines whether the background will use an image or a solid color.",
             "options": [
               {
                 "text": "Color",
@@ -59,13 +66,13 @@
             "type": "uploader",
             "key": "close_button_image",
             "label": "Close Button Image",
-            "label_tooltip": "Image for the screen background."
+            "label_tooltip": "Image for the close button of the screen."
           },
           {
             "type": "select",
             "key": "close_button_position",
             "label": "Close Button Position",
-            "tooltip_text": "Determines the corner side of the screen where the button is placed.",
+            "label_tooltip": "Determines the corner side of the screen where the button is placed.",
             "options": [
               {
                 "text": "Left",
@@ -117,7 +124,7 @@
             "type": "select",
             "key": "instructions_text_transform",
             "label": "Instructions Text Transform",
-            "tooltip_text": "Reformats the Instructions Text if needed.",
+            "label_tooltip": "Reformats the Instructions Text if needed.",
             "options": [
               {
                 "text": "None",
@@ -177,7 +184,7 @@
             "type": "select",
             "key": "challenge_text_transform",
             "label": "Challenge Text Transform",
-            "tooltip_text": "Reformats the Code/Challenge Text if needed.",
+            "label_tooltip": "Reformats the Code/Challenge Text if needed.",
             "options": [
               {
                 "text": "None",
@@ -202,7 +209,7 @@
             "type": "number_input",
             "key": "challenge_text_margin",
             "label": "Challenge Text Margin",
-            "label_tooltip": "Margin between the Instructions section and the Code/Challenge section.",
+            "label_tooltip": "Margin between the Code/Challenge section and the Indicators/Answer section.",
             "initial_value": "16"
           },
           {
@@ -244,7 +251,7 @@
             "type": "select",
             "key": "error_message_text_transform",
             "label": "Error Message Text Transform",
-            "tooltip_text": "Reformats the Error Message Text if needed.",
+            "label_tooltip": "Reformats the Error Message Text if needed.",
             "options": [
               {
                 "text": "None",
@@ -425,9 +432,30 @@
       }
     ]
   },
-  "styles": {},
-  "data": {},
-  "localizations": {},
+  "export": {
+    "allowed_list": [
+      {
+        "identifier": "quick-brick-inplayer",
+        "group": {
+          "label": "Parent Lock Import",
+          "folded": true
+        },
+        "section": "styles",
+        "allowed_fields": [
+          {
+            "section": "general",
+            "key": "import_parent_lock",
+            "min_zapp_sdk": {
+              "ios": "20.2.0-Dev",
+              "android": "20.0.0",
+              "ios_for_quickbrick": "0.1.0-alpha1",
+              "android_for_quickbrick": "0.1.0-alpha1"
+            }
+          }
+        ]
+      }
+    ]
+  },
   "targets": [
     "mobile"
   ],
@@ -435,8 +463,8 @@
     "quickbrick"
   ],
   "platform": "android_for_quickbrick",
-  "dependency_version": "0.0.8",
-  "manifest_version": "0.0.8",
+  "dependency_version": "0.0.9",
+  "manifest_version": "0.0.9",
   "min_zapp_sdk": "0.1.0-alpha1",
   "npm_dependencies": []
 }

--- a/plugins/quick-brick-parent-lock/manifests/android_for_quickbrick.json
+++ b/plugins/quick-brick-parent-lock/manifests/android_for_quickbrick.json
@@ -435,8 +435,8 @@
     "quickbrick"
   ],
   "platform": "android_for_quickbrick",
-  "dependency_version": "0.0.7",
-  "manifest_version": "0.0.7",
+  "dependency_version": "0.0.8",
+  "manifest_version": "0.0.8",
   "min_zapp_sdk": "0.1.0-alpha1",
   "npm_dependencies": []
 }

--- a/plugins/quick-brick-parent-lock/manifests/ios.json
+++ b/plugins/quick-brick-parent-lock/manifests/ios.json
@@ -20,6 +20,13 @@
   "general": {
     "fields": [
       {
+        "type": "switch",
+        "key": "import_parent_lock",
+        "label": "Import Parent Lock",
+        "label_tooltip": "Import Parent lock in other supported plugins.",
+        "initial_value": "true"
+      },
+      {
         "group": true,
         "label": "Screen Design and Text",
         "tooltip": "These fields affect the design of the main screen plugin.",
@@ -29,7 +36,7 @@
             "type": "select",
             "key": "background_type",
             "label": "Background type",
-            "tooltip_text": "Defines whether the background will use an image or a solid color.",
+            "label_tooltip": "Defines whether the background will use an image or a solid color.",
             "options": [
               {
                 "text": "Color",
@@ -59,13 +66,13 @@
             "type": "uploader",
             "key": "close_button_image",
             "label": "Close Button Image",
-            "label_tooltip": "Image for the screen background."
+            "label_tooltip": "Image for the close button of the screen."
           },
           {
             "type": "select",
             "key": "close_button_position",
             "label": "Close Button Position",
-            "tooltip_text": "Determines the corner side of the screen where the button is placed.",
+            "label_tooltip": "Determines the corner side of the screen where the button is placed.",
             "options": [
               {
                 "text": "Left",
@@ -117,7 +124,7 @@
             "type": "select",
             "key": "instructions_text_transform",
             "label": "Instructions Text Transform",
-            "tooltip_text": "Reformats the Instructions Text if needed.",
+            "label_tooltip": "Reformats the Instructions Text if needed.",
             "options": [
               {
                 "text": "None",
@@ -177,7 +184,7 @@
             "type": "select",
             "key": "challenge_text_transform",
             "label": "Challenge Text Transform",
-            "tooltip_text": "Reformats the Code/Challenge Text if needed.",
+            "label_tooltip": "Reformats the Code/Challenge Text if needed.",
             "options": [
               {
                 "text": "None",
@@ -202,7 +209,7 @@
             "type": "number_input",
             "key": "challenge_text_margin",
             "label": "Challenge Text Margin",
-            "label_tooltip": "Margin between the Instructions section and the Code/Challenge section.",
+            "label_tooltip": "Margin between the Code/Challenge section and the Indicators/Answer section.",
             "initial_value": "16"
           },
           {
@@ -244,7 +251,7 @@
             "type": "select",
             "key": "error_message_text_transform",
             "label": "Error Message Text Transform",
-            "tooltip_text": "Reformats the Error Message Text if needed.",
+            "label_tooltip": "Reformats the Error Message Text if needed.",
             "options": [
               {
                 "text": "None",
@@ -425,9 +432,30 @@
       }
     ]
   },
-  "styles": {},
-  "data": {},
-  "localizations": {},
+  "export": {
+    "allowed_list": [
+      {
+        "identifier": "quick-brick-inplayer",
+        "group": {
+          "label": "Parent Lock Import",
+          "folded": true
+        },
+        "section": "styles",
+        "allowed_fields": [
+          {
+            "section": "general",
+            "key": "import_parent_lock",
+            "min_zapp_sdk": {
+              "ios": "20.2.0-Dev",
+              "android": "20.0.0",
+              "ios_for_quickbrick": "0.1.0-alpha1",
+              "android_for_quickbrick": "0.1.0-alpha1"
+            }
+          }
+        ]
+      }
+    ]
+  },
   "targets": [
     "mobile"
   ],
@@ -435,8 +463,8 @@
     "quickbrick"
   ],
   "platform": "ios",
-  "dependency_version": "0.0.8",
-  "manifest_version": "0.0.8",
+  "dependency_version": "0.0.9",
+  "manifest_version": "0.0.9",
   "min_zapp_sdk": "20.0.0-Dev",
   "npm_dependencies": []
 }

--- a/plugins/quick-brick-parent-lock/manifests/ios.json
+++ b/plugins/quick-brick-parent-lock/manifests/ios.json
@@ -435,8 +435,8 @@
     "quickbrick"
   ],
   "platform": "ios",
-  "dependency_version": "0.0.7",
-  "manifest_version": "0.0.7",
+  "dependency_version": "0.0.8",
+  "manifest_version": "0.0.8",
   "min_zapp_sdk": "20.0.0-Dev",
   "npm_dependencies": []
 }

--- a/plugins/quick-brick-parent-lock/manifests/ios_for_quickbrick.json
+++ b/plugins/quick-brick-parent-lock/manifests/ios_for_quickbrick.json
@@ -20,6 +20,13 @@
   "general": {
     "fields": [
       {
+        "type": "switch",
+        "key": "import_parent_lock",
+        "label": "Import Parent Lock",
+        "label_tooltip": "Import Parent lock in other supported plugins.",
+        "initial_value": "true"
+      },
+      {
         "group": true,
         "label": "Screen Design and Text",
         "tooltip": "These fields affect the design of the main screen plugin.",
@@ -29,7 +36,7 @@
             "type": "select",
             "key": "background_type",
             "label": "Background type",
-            "tooltip_text": "Defines whether the background will use an image or a solid color.",
+            "label_tooltip": "Defines whether the background will use an image or a solid color.",
             "options": [
               {
                 "text": "Color",
@@ -59,13 +66,13 @@
             "type": "uploader",
             "key": "close_button_image",
             "label": "Close Button Image",
-            "label_tooltip": "Image for the screen background."
+            "label_tooltip": "Image for the close button of the screen."
           },
           {
             "type": "select",
             "key": "close_button_position",
             "label": "Close Button Position",
-            "tooltip_text": "Determines the corner side of the screen where the button is placed.",
+            "label_tooltip": "Determines the corner side of the screen where the button is placed.",
             "options": [
               {
                 "text": "Left",
@@ -117,7 +124,7 @@
             "type": "select",
             "key": "instructions_text_transform",
             "label": "Instructions Text Transform",
-            "tooltip_text": "Reformats the Instructions Text if needed.",
+            "label_tooltip": "Reformats the Instructions Text if needed.",
             "options": [
               {
                 "text": "None",
@@ -177,7 +184,7 @@
             "type": "select",
             "key": "challenge_text_transform",
             "label": "Challenge Text Transform",
-            "tooltip_text": "Reformats the Code/Challenge Text if needed.",
+            "label_tooltip": "Reformats the Code/Challenge Text if needed.",
             "options": [
               {
                 "text": "None",
@@ -202,7 +209,7 @@
             "type": "number_input",
             "key": "challenge_text_margin",
             "label": "Challenge Text Margin",
-            "label_tooltip": "Margin between the Instructions section and the Code/Challenge section.",
+            "label_tooltip": "Margin between the Code/Challenge section and the Indicators/Answer section.",
             "initial_value": "16"
           },
           {
@@ -244,7 +251,7 @@
             "type": "select",
             "key": "error_message_text_transform",
             "label": "Error Message Text Transform",
-            "tooltip_text": "Reformats the Error Message Text if needed.",
+            "label_tooltip": "Reformats the Error Message Text if needed.",
             "options": [
               {
                 "text": "None",
@@ -425,9 +432,30 @@
       }
     ]
   },
-  "styles": {},
-  "data": {},
-  "localizations": {},
+  "export": {
+    "allowed_list": [
+      {
+        "identifier": "quick-brick-inplayer",
+        "group": {
+          "label": "Parent Lock Import",
+          "folded": true
+        },
+        "section": "styles",
+        "allowed_fields": [
+          {
+            "section": "general",
+            "key": "import_parent_lock",
+            "min_zapp_sdk": {
+              "ios": "20.2.0-Dev",
+              "android": "20.0.0",
+              "ios_for_quickbrick": "0.1.0-alpha1",
+              "android_for_quickbrick": "0.1.0-alpha1"
+            }
+          }
+        ]
+      }
+    ]
+  },
   "targets": [
     "mobile"
   ],
@@ -435,8 +463,8 @@
     "quickbrick"
   ],
   "platform": "ios_for_quickbrick",
-  "dependency_version": "0.0.8",
-  "manifest_version": "0.0.8",
+  "dependency_version": "0.0.9",
+  "manifest_version": "0.0.9",
   "min_zapp_sdk": "0.1.0-alpha1",
   "npm_dependencies": []
 }

--- a/plugins/quick-brick-parent-lock/manifests/ios_for_quickbrick.json
+++ b/plugins/quick-brick-parent-lock/manifests/ios_for_quickbrick.json
@@ -435,8 +435,8 @@
     "quickbrick"
   ],
   "platform": "ios_for_quickbrick",
-  "dependency_version": "0.0.7",
-  "manifest_version": "0.0.7",
+  "dependency_version": "0.0.8",
+  "manifest_version": "0.0.8",
   "min_zapp_sdk": "0.1.0-alpha1",
   "npm_dependencies": []
 }

--- a/plugins/quick-brick-parent-lock/manifests/manifest.config.js
+++ b/plugins/quick-brick-parent-lock/manifests/manifest.config.js
@@ -29,6 +29,13 @@ const baseManifest = {
   general: {
     fields: [
       {
+        type: "switch",
+        key: "import_parent_lock",
+        label: "Import Parent Lock",
+        label_tooltip: "Import Parent lock in other supported plugins.",
+        initial_value: "true",
+      },
+      {
         group: true,
         label: "Screen Design and Text",
         tooltip: "These fields affect the design of the main screen plugin.",
@@ -38,7 +45,7 @@ const baseManifest = {
             type: "select",
             key: "background_type",
             label: "Background type",
-            tooltip_text:
+            label_tooltip:
               "Defines whether the background will use an image or a solid color.",
             options: [
               {
@@ -69,13 +76,13 @@ const baseManifest = {
             type: "uploader",
             key: "close_button_image",
             label: "Close Button Image",
-            label_tooltip: "Image for the screen background.",
+            label_tooltip: "Image for the close button of the screen.",
           },
           {
             type: "select",
             key: "close_button_position",
             label: "Close Button Position",
-            tooltip_text:
+            label_tooltip:
               "Determines the corner side of the screen where the button is placed.",
             options: [
               {
@@ -129,7 +136,7 @@ const baseManifest = {
             type: "select",
             key: "instructions_text_transform",
             label: "Instructions Text Transform",
-            tooltip_text: "Reformats the Instructions Text if needed.",
+            label_tooltip: "Reformats the Instructions Text if needed.",
             options: [
               {
                 text: "None",
@@ -192,7 +199,7 @@ const baseManifest = {
             type: "select",
             key: "challenge_text_transform",
             label: "Challenge Text Transform",
-            tooltip_text: "Reformats the Code/Challenge Text if needed.",
+            label_tooltip: "Reformats the Code/Challenge Text if needed.",
             options: [
               {
                 text: "None",
@@ -218,7 +225,7 @@ const baseManifest = {
             key: "challenge_text_margin",
             label: "Challenge Text Margin",
             label_tooltip:
-              "Margin between the Instructions section and the Code/Challenge section.",
+              "Margin between the Code/Challenge section and the Indicators/Answer section.",
             initial_value: "16",
           },
           {
@@ -260,7 +267,7 @@ const baseManifest = {
             type: "select",
             key: "error_message_text_transform",
             label: "Error Message Text Transform",
-            tooltip_text: "Reformats the Error Message Text if needed.",
+            label_tooltip: "Reformats the Error Message Text if needed.",
             options: [
               {
                 text: "None",
@@ -448,9 +455,30 @@ const baseManifest = {
       },
     ],
   },
-  styles: {},
-  data: {},
-  localizations: {},
+  export: {
+    allowed_list: [
+      {
+        identifier: "quick-brick-inplayer",
+        group: {
+          label: "Parent Lock Import",
+          folded: true,
+        },
+        section: "styles",
+        allowed_fields: [
+          {
+            section: "general",
+            key: "import_parent_lock",
+            min_zapp_sdk: {
+              ios: "20.2.0-Dev",
+              android: "20.0.0",
+              ios_for_quickbrick: "0.1.0-alpha1",
+              android_for_quickbrick: "0.1.0-alpha1",
+            },
+          },
+        ],
+      },
+    ],
+  },
   targets: ["mobile"],
   ui_frameworks: ["quickbrick"],
 };

--- a/plugins/quick-brick-parent-lock/package.json
+++ b/plugins/quick-brick-parent-lock/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@applicaster/quick-brick-parent-lock",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/plugins/quick-brick-parent-lock/package.json
+++ b/plugins/quick-brick-parent-lock/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@applicaster/quick-brick-parent-lock",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Found out today that version 0.0.5 of the Parent Lock plugin was never published to Github or NPM. So when I pushed 0.0.6 and 0.0.7 it was missing changes that were published to Zapp previously.

This PR brings in those manifest changes from: https://zapp.applicaster.com/admin/plugin_versions/19776/plugin_manifests/19776#

