### PR TITLE
google ima to prevent multiple pause events IM-858

### DIFF
--- a/FrameworksData.plist
+++ b/FrameworksData.plist
@@ -5,7 +5,7 @@
 	<key>ZappGoogleInteractiveMediaAds</key>
 	<dict>
 		<key>version_id</key>
-		<string>0.12.0</string>
+		<string>0.12.1</string>
 	</dict>
 	<key>quick-brick-circle-ci-test</key>
 	<dict>

--- a/plugins/ZappGoogleInteractiveMediaAds/Universal/GoogleInteractiveMediaAdsAdapter/GoogleInteractiveMediaAdsAdapter+QBPlayerObserverProtocol.swift
+++ b/plugins/ZappGoogleInteractiveMediaAds/Universal/GoogleInteractiveMediaAdsAdapter/GoogleInteractiveMediaAdsAdapter+QBPlayerObserverProtocol.swift
@@ -64,10 +64,6 @@ extension GoogleInteractiveMediaAdsAdapter: PlayerObserverProtocol {
     }
 
     public func playerDidCreate(player: PlayerProtocol) {
-    
-        DispatchQueue.main.asyncAfter(deadline: .now() + 1.1) {
-            self.prepareGoogleIMA()
-        }
+        self.prepareGoogleIMA()
     }
-    
 }

--- a/plugins/ZappGoogleInteractiveMediaAds/Universal/GoogleInteractiveMediaAdsAdapter/GoogleInteractiveMediaAdsAdapter+QBPlayerObserverProtocol.swift
+++ b/plugins/ZappGoogleInteractiveMediaAds/Universal/GoogleInteractiveMediaAdsAdapter/GoogleInteractiveMediaAdsAdapter+QBPlayerObserverProtocol.swift
@@ -64,6 +64,10 @@ extension GoogleInteractiveMediaAdsAdapter: PlayerObserverProtocol {
     }
 
     public func playerDidCreate(player: PlayerProtocol) {
-        prepareGoogleIMA()
+    
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.1) {
+            self.prepareGoogleIMA()
+        }
     }
+    
 }

--- a/plugins/ZappGoogleInteractiveMediaAds/Universal/GoogleInteractiveMediaAdsAdapter/GoogleInteractiveMediaAdsAdapter+QBPlayerObserverProtocol.swift
+++ b/plugins/ZappGoogleInteractiveMediaAds/Universal/GoogleInteractiveMediaAdsAdapter/GoogleInteractiveMediaAdsAdapter+QBPlayerObserverProtocol.swift
@@ -64,6 +64,6 @@ extension GoogleInteractiveMediaAdsAdapter: PlayerObserverProtocol {
     }
 
     public func playerDidCreate(player: PlayerProtocol) {
-        self.prepareGoogleIMA()
+        prepareGoogleIMA()
     }
 }

--- a/plugins/ZappGoogleInteractiveMediaAds/Universal/GoogleInteractiveMediaAdsAdapter/GoogleInteractiveMediaAdsAdapter.swift
+++ b/plugins/ZappGoogleInteractiveMediaAds/Universal/GoogleInteractiveMediaAdsAdapter/GoogleInteractiveMediaAdsAdapter.swift
@@ -93,7 +93,6 @@ import ZappCore
 
         if let urlToPresent = urlTagData?.prerollUrlString() {
             isPrerollAdLoading = true
-            pausePlayback()
             requestAd(adUrl: urlToPresent)
         }
         


### PR DESCRIPTION
https://applicaster.atlassian.net/browse/IM-858

the goal is to prevent multiple pause event sent to analytics, with the ads plugin with prerole.

problem:
today while the video start, the ad plugin send pause request to the player and begin the ad.

in this time the default player send multiple resume events to the player you can see for example in:

 @objc public var src: NSDictionary? {
        didSet {
....
DispatchQueue.main.asyncAfter(deadline: .now() + 1) { [weak self] in
}

solution:
remove the pause for player while the ad is init, (it will get paused later)